### PR TITLE
docs: update invalid RPC docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It is a modern, high-level framework on top of popular specific Python brokers l
   * **Kafka** (based on <a href="https://aiokafka.readthedocs.io/en/stable/" target="_blank">aiokafka</a>)
   * **SQS** (based on <a href="https://aiobotocore.readthedocs.io/en/latest/" target="_blank">aiobotocore</a>)
   * **Nats** (based on <a href="https://github.com/nats-io/nats.py" target="_blank">nats-py</a>)
-* <a href="https://lancetnik.github.io/Propan/getting_started/4_broker/5_rpc/" target="_blank">**RPC**</a>: The framework supports RPC requests over MQ, which will allow performing long operations on remote services asynchronously.
+* <a href="https://lancetnik.github.io/Propan/getting_started/4_broker/6_rpc/" target="_blank">**RPC**</a>: The framework supports RPC requests over MQ, which will allow performing long operations on remote services asynchronously.
 * [**Great to develop**](#cli-power): CLI tool provides great development experience:
   * framework-independent way to manage the project environment
   * application code *hot reload*


### PR DESCRIPTION
Just a small docs fix. 

RPC documentation link was invalid in README.md

