### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/docs/en/nats/2_publishing.md
+++ b/docs/docs/en/nats/2_publishing.md
@@ -17,7 +17,7 @@ asyncio.run(pub())
 
 The `publish` method accepts the following arguments:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel - message to send
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel - message to send
 * `subject`: str - *subject*, where the message will be sent.
 
 ## Message Parameters

--- a/docs/docs/en/rabbit/4_publishing.md
+++ b/docs/docs/en/rabbit/4_publishing.md
@@ -9,7 +9,7 @@ from propan import RabbitBroker
 
 async def pub():
     async with RabbitBroker() as broker:
-        await broker.publish("Hi!", queue="test", exhcange="test")
+        await broker.publish("Hi!", queue="test", exchange="test")
 
 asyncio.run(pub())
 ```

--- a/docs/docs/en/rabbit/4_publishing.md
+++ b/docs/docs/en/rabbit/4_publishing.md
@@ -1,7 +1,7 @@
 # Rabbit Publishing
 
 `RabbitBroker` also uses the unified `publish` method to send messages.
-However, in this case, an object of the `aio_pika.Message` class (if necessary) can act as a message (in addition to `str`, `bytes`, `dict`, `pydatic.BaseModel`).
+However, in this case, an object of the `aio_pika.Message` class (if necessary) can act as a message (in addition to `str`, `bytes`, `dict`, `pydantic.BaseModel`).
 
 ```python
 import asyncio
@@ -18,7 +18,7 @@ asyncio.run(pub())
 
 The `publish` method takes the following arguments:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel | aio_pika.Message = "" - message to send
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel | aio_pika.Message = "" - message to send
 * `exchange`: str | RabbitExchange | None = None - the exchange where the message will be sent to. If not specified - *default* is used
 * `queue`: str | RabbitQueue = "" - the queue where the message will be sent (since most queues use their name as the routing key, this is a human-readable version of `routing_key`)
 * `routing_key`: str = "" - also a message routing key, if not specified, the `queue` argument is used

--- a/docs/docs/en/redis/2_publishing.md
+++ b/docs/docs/en/redis/2_publishing.md
@@ -17,7 +17,7 @@ asyncio.run(pub())
 
 The `publish` method accepts the following arguments:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel - message to send
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel - message to send
 * `channel`: str = "" - *channel* to which the message will be sent.
 
 ## Message Parameters

--- a/docs/docs/ru/nats/2_publishing.md
+++ b/docs/docs/ru/nats/2_publishing.md
@@ -17,7 +17,7 @@ asyncio.run(pub())
 
 Метод `publish` принимает следующие аргументы:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel - сообщение для отправки
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel - сообщение для отправки
 * `subject`: str - *subject*, куда будет отправлено сообщение.
 
 ## Параметры сообщения

--- a/docs/docs/ru/rabbit/4_publishing.md
+++ b/docs/docs/ru/rabbit/4_publishing.md
@@ -9,7 +9,7 @@ from propan import RabbitBroker
 
 async def pub():
     async with RabbitBroker() as broker:
-        await broker.publish("Hi!", queue="test", exhcange="test")
+        await broker.publish("Hi!", queue="test", exchange="test")
 
 asyncio.run(pub())
 ```

--- a/docs/docs/ru/rabbit/4_publishing.md
+++ b/docs/docs/ru/rabbit/4_publishing.md
@@ -1,7 +1,7 @@
 # Rabbit Publishing
 
 Для отправки сообщений `RabbitBroker` также использует унифицированный метод `publish`.
-Однако, в данном случае в качестве сообщения (помимо `str`, `bytes`, `dict`, `pydatic.BaseModel`) может выступать объект класса `aio_pika.Message` (при необходимости).
+Однако, в данном случае в качестве сообщения (помимо `str`, `bytes`, `dict`, `pydantic.BaseModel`) может выступать объект класса `aio_pika.Message` (при необходимости).
 
 ```python
 import asyncio
@@ -18,7 +18,7 @@ asyncio.run(pub())
 
 Метод `publish` принимает следующие аргументы:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel | aio_pika.Message = "" - сообщение для отправки
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel | aio_pika.Message = "" - сообщение для отправки
 * `exchange`: str | RabbitExchange | None = None - exchange, куда будет отправлено сообщение. Если не указан - используется *default*
 * `queue`: str | RabbitQueue = "" - очередь, куда будет отправлено сообщение (т.к. большинство очередей используют свое название в качестве ключа маршрутизации, это человекочитаемый вариант `routing_key`)
 * `routing_key`: str = "" - тоже ключ маршрутизации сообщения, если не указан - используется аргумент `queue`

--- a/docs/docs/ru/redis/2_publishing.md
+++ b/docs/docs/ru/redis/2_publishing.md
@@ -17,7 +17,7 @@ asyncio.run(pub())
 
 Метод `publish` принимает следующие аргументы:
 
-* `message`: bytes | str | dict | Sequence[Any] | pydatic.BaseModel - сообщение для отправки
+* `message`: bytes | str | dict | Sequence[Any] | pydantic.BaseModel - сообщение для отправки
 * `channel`: str = "" - *channel*, куда будет отправлено сообщение.
 
 ## Параметры сообщения


### PR DESCRIPTION
# Description

This PR fixes a couple of typos in the docs (in all files where they occur):
- `exhcange` -> `exchange`
- `pydatic` -> `pydantic`

## Type of change

- [X] Documentation (typos, code examples or any documentation update)
