### PR TITLE
Fix: ssl_context argument to Kafka consumer wrapper

### DIFF
--- a/propan/__about__.py
+++ b/propan/__about__.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-__version__ = "0.1.5.17"
+__version__ = "0.1.5.18"
 
 
 INSTALL_MESSAGE = (

--- a/propan/brokers/kafka/kafka_broker.py
+++ b/propan/brokers/kafka/kafka_broker.py
@@ -105,6 +105,7 @@ class KafkaBroker(
                 "sasl_kerberos_service_name",
                 "sasl_kerberos_domain_name",
                 "sasl_oauth_token_provider",
+                "ssl_context",
             }
             and v
         }


### PR DESCRIPTION
# Description

Fix for bug with ssl_context not being passed via propan.fastapi.KafkaRouter to aiokafka.AIOKafkaConsumer
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (`scripts/lint.sh` has no errors)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I added a code examples to illustrate the changes
